### PR TITLE
Process book lists in unread folder

### DIFF
--- a/src/routes/unread/+page.svelte
+++ b/src/routes/unread/+page.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { get_all_book_lists } from './books.remote';
+</script>
+
+<svelte:head>
+	<title>Unread | Brandon Pittman</title>
+</svelte:head>
+
+<article id="unread" class="prose flow-xs">
+	<h1>Book Lists</h1>
+
+	<p>
+		Interested in audiobooks? Check out{' '}
+		<a
+			href="https://libro.fm/referral?rf_code=lfm486721?utm_source=Libro.fm&utm_medium=email&utm_campaign=Transactional_order_confirmation"
+			target="_blank"
+			rel="noopener noreferrer"
+		>
+			Libro.fm
+		</a>
+		.
+	</p>
+
+	<ul class="flow" role="list">
+		{#each await get_all_book_lists() as list (list.slug)}
+			<li>
+				<a href="/unread/{list.slug}">
+					{list.title}
+				</a>
+			</li>
+		{/each}
+	</ul>
+</article>

--- a/src/routes/unread/[slug]/+page.svelte
+++ b/src/routes/unread/[slug]/+page.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { get_book_list } from '../books.remote';
+
+	let param = $derived(page.params.slug);
+	let book_list = $derived(await get_book_list(param!));
+</script>
+
+<svelte:head>
+	<title>{book_list.meta.title || param} | Brandon Pittman</title>
+</svelte:head>
+
+<article class="prose">
+	{@html book_list.content}
+</article>

--- a/src/routes/unread/books.remote.ts
+++ b/src/routes/unread/books.remote.ts
@@ -1,0 +1,69 @@
+import { query } from '$app/server';
+import { error } from '@sveltejs/kit';
+import matter, { type Input } from 'gray-matter';
+import { Marked } from 'marked';
+import { markedHighlight } from 'marked-highlight';
+import * as z from 'zod/mini';
+import hljs from 'highlight.js/lib/common';
+
+export type BookList = {
+	slug: string;
+	meta: Record<string, any>;
+	content: string;
+};
+
+const marked = new Marked(
+	markedHighlight({
+		emptyLangClass: 'hljs',
+		langPrefix: 'hljs language-',
+		highlight(code, lang) {
+			const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+			return hljs.highlight(code, { language }).value;
+		}
+	})
+);
+
+// Load all book list files at module scope
+const book_list_modules = import.meta.glob('/content/unread/*.md', {
+	eager: true,
+	query: '?raw',
+	import: 'default'
+});
+
+const book_lists = Object.entries(book_list_modules).reduce(
+	(acc, [path, content]) => {
+		const slug = path.split('/').pop()?.replace('.md', '') || '';
+		acc[slug] = content as string;
+		return acc;
+	},
+	{} as Record<string, string>
+);
+
+export const get_book_list = query(z.string(), async (slug) => {
+	const raw = book_lists[slug];
+
+	if (!raw) {
+		throw error(404, 'Book list not found');
+	}
+
+	const { data, content: markdown } = matter(raw as Input);
+
+	return {
+		slug,
+		meta: data,
+		content: marked.parse(markdown)
+	};
+});
+
+export const get_all_book_lists = query(z.void(), async () => {
+	return Object.keys(book_lists).map((slug) => {
+		const raw = book_lists[slug];
+		const { data } = matter(raw as Input);
+
+		return {
+			slug,
+			title: data.title || slug,
+			...data
+		};
+	});
+});


### PR DESCRIPTION
- Created books.remote.ts loader with marked-highlight integration
- Added /unread main page listing all book lists
- Added /unread/[slug] pages for individual lists (read, unread, reading, abandoned)
- Applied same syntax highlighting configuration as notes