### PR TITLE
Add note support to book list parser and component

### DIFF
--- a/src/lib/books.remote.ts
+++ b/src/lib/books.remote.ts
@@ -4,6 +4,7 @@ import * as z from 'zod/mini';
 export type Book = {
 	title: string;
 	author: string;
+	note?: string;
 };
 
 export type BookList = {
@@ -20,13 +21,14 @@ const book_modules = import.meta.glob('/content/unread/*.md', {
 
 // Parse book entry line
 function parse_book_line(line: string): Book | null {
-	// Match: "- Title (Author)" or "* Title (Author)"
-	const match = line.match(/^[*-]\s+(.+?)\s+\(([^)]+)\)$/);
+	// Match: "- Title (Author)" or "- Title (Author) (Note)"
+	const match = line.match(/^[*-]\s+(.+?)\s+\(([^)]+)\)(?:\s+\(([^)]+)\))?$/);
 	if (!match) return null;
 
 	return {
 		title: match[1].trim(),
-		author: match[2].trim()
+		author: match[2].trim(),
+		note: match[3]?.trim()
 	};
 }
 

--- a/src/lib/components/BookList.svelte
+++ b/src/lib/components/BookList.svelte
@@ -9,6 +9,9 @@
 		<li>
 			{book.title}
 			<span>{book.author}</span>
+			{#if book.note}
+				<span>{book.note}</span>
+			{/if}
 		</li>
 	{/each}
 </ul>
@@ -38,5 +41,13 @@
 	span {
 		color: #999;
 		font-size: 9px;
+	}
+
+	span + span {
+		font-size: 11px;
+		line-height: 13px;
+		display: block;
+		position: relative;
+		top: -2px;
 	}
 </style>


### PR DESCRIPTION
Updated books.remote.ts and BookList.svelte to support optional third parenthetical section for notes, matching the game list implementation.

Parser now supports both formats:
- Title (Author)
- Title (Author) (Note)

The second span gets special styling (larger font, displayed as block on second line) via the `span + span` CSS selector, matching the PHP implementation where the note displays below the title and author.

本リストパーサーとコンポーネントにメモサポートを追加

ゲームリストの実装と同じように、メモ用のオプション第三括弧セクションを
サポートするようにbooks.remote.tsとBookList.svelteを更新。